### PR TITLE
Add null check in Queue::isCurrentlyPlaying

### DIFF
--- a/src/core/soloud_queue.cpp
+++ b/src/core/soloud_queue.cpp
@@ -160,6 +160,10 @@ namespace SoLoud
 		if (mSoloud == 0 || mCount == 0 || aSound.mAudioSourceID == 0)
 			return false;
 		mSoloud->lockAudioMutex_internal();
+		if (mSource[mReadIndex] == nullptr) {
+			mSoloud->unlockAudioMutex_internal();
+			return false;
+		}
 		bool res = mSource[mReadIndex]->mAudioSourceID == aSound.mAudioSourceID;
 		mSoloud->unlockAudioMutex_internal();
 		return res;


### PR DESCRIPTION
This fixes a rare crash, so far only observed on a single cortex-a53-based platform.